### PR TITLE
[BE] 로그인 기능 구현 GET /api/login/token ,

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -23,9 +23,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // MapStruct : mapper
+    implementation 'org.mapstruct:mapstruct:1.5.1.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.1.Final'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     // db
     runtimeOnly 'com.h2database:h2'
@@ -50,6 +55,7 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured'
 }
 
 //Querydsl 추가, 자동 생성된 Q클래스 gradle clean으로 제거

--- a/be/src/main/java/dev/kukim/issues/user/auth/controller/LoginController.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/controller/LoginController.java
@@ -1,0 +1,23 @@
+package dev.kukim.issues.user.auth.controller;
+
+import dev.kukim.issues.user.auth.controller.response.LoginResponse;
+import dev.kukim.issues.user.auth.service.LoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/login")
+public class LoginController {
+
+	private final LoginService loginService;
+
+	@GetMapping("/token")
+	public LoginResponse login(@RequestParam String code) {
+		return loginService.createToken(code);
+	}
+
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/controller/request/TokenRequest.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/controller/request/TokenRequest.java
@@ -1,0 +1,19 @@
+package dev.kukim.issues.user.auth.controller.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TokenRequest {
+
+	private final String clientId;
+
+	private final String clientSecret;
+
+	private final String code;
+
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/controller/response/GithubUserResponse.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/controller/response/GithubUserResponse.java
@@ -1,0 +1,16 @@
+package dev.kukim.issues.user.auth.controller.response;
+
+import lombok.Getter;
+
+@Getter
+public class GithubUserResponse {
+
+	private Long id;
+
+	private String name;
+
+	private String email;
+
+	private String avatarUrl;
+
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/controller/response/LoginResponse.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/controller/response/LoginResponse.java
@@ -1,0 +1,23 @@
+package dev.kukim.issues.user.auth.controller.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class LoginResponse {
+
+	private String accessToken;
+
+	private String name;
+
+	private String email;
+
+	private String avatarUrl;
+
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/controller/response/TokenResponse.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/controller/response/TokenResponse.java
@@ -1,0 +1,16 @@
+package dev.kukim.issues.user.auth.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonProperty("scope")
+	private String scope;
+
+	@JsonProperty("token_type")
+	private String tokenType;
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/mapper/LoginResponseMapper.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/mapper/LoginResponseMapper.java
@@ -1,0 +1,14 @@
+package dev.kukim.issues.user.auth.mapper;
+
+import dev.kukim.issues.user.auth.controller.response.LoginResponse;
+import dev.kukim.issues.user.user.domain.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface LoginResponseMapper {
+
+	LoginResponseMapper INSTANCE = Mappers.getMapper(LoginResponseMapper.class);
+
+	LoginResponse map(User user, String accessToken);
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/property/GithubProperty.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/property/GithubProperty.java
@@ -1,0 +1,22 @@
+package dev.kukim.issues.user.auth.property;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class GithubProperty {
+
+	@Value("${oauth.provider.github.token-uri}")
+	private String accessTokenUri;
+
+	@Value("${oauth.provider.github.user-info}")
+	private String userInfoUri;
+
+	@Value("${oauth.client.github.client.id}")
+	private String clientId;
+
+	@Value("${oauth.client.github.client.secret}")
+	private String clientSecret;
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/service/LoginService.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/service/LoginService.java
@@ -1,0 +1,74 @@
+package dev.kukim.issues.user.auth.service;
+
+import dev.kukim.issues.user.auth.controller.request.TokenRequest;
+import dev.kukim.issues.user.auth.controller.response.GithubUserResponse;
+import dev.kukim.issues.user.auth.controller.response.LoginResponse;
+import dev.kukim.issues.user.auth.controller.response.TokenResponse;
+import dev.kukim.issues.user.auth.mapper.LoginResponseMapper;
+import dev.kukim.issues.user.auth.property.GithubProperty;
+import dev.kukim.issues.user.user.domain.User;
+import dev.kukim.issues.user.user.domain.repository.UserRepository;
+import dev.kukim.issues.user.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+	public static final String TOKEN = "token";
+
+	private final GithubProperty githubProperty;
+	private final UserRepository userRepository;
+	private final LoginTokenGenerator loginTokenGenerator;
+
+	public LoginResponse createToken(String code) {
+		GithubUserResponse githubUserResponse = getGithubUserResponse(code);
+
+		User user = findOrCreatUser(githubUserResponse);
+
+		String accessToken = loginTokenGenerator.accessToken(user.getId());
+
+		return LoginResponseMapper.INSTANCE.map(user, accessToken);
+	}
+
+	private User findOrCreatUser(GithubUserResponse githubUserResponse) {
+		Long findId = githubUserResponse.getId();
+
+		return userRepository.findById(findId).orElseGet(() ->
+			userRepository.save(UserMapper.INSTANCE.map(githubUserResponse)));
+	}
+
+	private GithubUserResponse getGithubUserResponse(String code) {
+		// TODO : 예외처리
+		return WebClient.create()
+			.get()
+			.uri(githubProperty.getUserInfoUri())
+			.accept(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, TOKEN + " " + getToken(code).getAccessToken())
+			.retrieve()
+			.bodyToMono(GithubUserResponse.class)
+			.block();
+	}
+
+	private TokenResponse getToken(String code) {
+		TokenRequest tokenRequest = TokenRequest.builder()
+			.clientId(githubProperty.getClientId())
+			.clientSecret(githubProperty.getClientSecret())
+			.code(code)
+			.build();
+
+		// TODO : 예외처리
+		return WebClient.create()
+			.post()
+			.uri(githubProperty.getAccessTokenUri())
+			.accept(MediaType.APPLICATION_JSON)
+			.bodyValue(tokenRequest)
+			.retrieve()
+			.bodyToMono(TokenResponse.class)
+			.block();
+	}
+}

--- a/be/src/main/java/dev/kukim/issues/user/auth/service/LoginTokenGenerator.java
+++ b/be/src/main/java/dev/kukim/issues/user/auth/service/LoginTokenGenerator.java
@@ -1,0 +1,40 @@
+package dev.kukim.issues.user.auth.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.time.Instant;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class LoginTokenGenerator {
+
+	public static final long HALF_HOUR = 30L;
+	@Value("${jwt.secret}")
+	private String jwtSecret;
+
+	public String accessToken(Long userId) {
+		return loginToken(userId, Date.from(Instant.now().plusSeconds(60 * HALF_HOUR)));
+	}
+
+	private String loginToken(Long userId, Date plusMinutes) {
+		SecretKey secretKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+
+		return Jwts.builder()
+			.setHeader(Map.of(
+				"typ", "JWT",
+				"alg", "HS256",
+				"regDate", System.currentTimeMillis()))
+			.setClaims(Map.of("userId", userId))
+			.setExpiration(plusMinutes)
+			.signWith(secretKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+}

--- a/be/src/main/java/dev/kukim/issues/user/user/domain/User.java
+++ b/be/src/main/java/dev/kukim/issues/user/user/domain/User.java
@@ -1,0 +1,29 @@
+package dev.kukim.issues.user.user.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+public class User {
+
+	@Id
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(length = 255)
+	private String email;
+
+	@Column(length = 1000)
+	private String avatarUrl;
+
+}

--- a/be/src/main/java/dev/kukim/issues/user/user/domain/repository/UserRepository.java
+++ b/be/src/main/java/dev/kukim/issues/user/user/domain/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package dev.kukim.issues.user.user.domain.repository;
+
+import dev.kukim.issues.user.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/be/src/main/java/dev/kukim/issues/user/user/mapper/UserMapper.java
+++ b/be/src/main/java/dev/kukim/issues/user/user/mapper/UserMapper.java
@@ -1,0 +1,14 @@
+package dev.kukim.issues.user.user.mapper;
+
+import dev.kukim.issues.user.auth.controller.response.GithubUserResponse;
+import dev.kukim.issues.user.user.domain.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface UserMapper {
+
+	UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+	User map(GithubUserResponse githubUserResponse);
+}

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,3 +1,9 @@
 spring:
   profiles:
     active: ${profile}
+
+
+# Default servlet contest-path
+server:
+  servlet:
+    context-path: /api

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   profiles:
     active: ${profile}
+  config:
+    import: classpath:auth/auth.yml
 
 
 # Default servlet contest-path

--- a/be/src/main/resources/auth/auth.yml
+++ b/be/src/main/resources/auth/auth.yml
@@ -1,0 +1,12 @@
+# oauth
+oauth:
+  client:
+    github:
+      client:
+        id: ${GITHUB_CLIENT_ID}
+        secret: ${GITHUB_CLIENT_SECRET}
+  provider:
+    github:
+      authorization-uri: https://github.com/login/oauth/authorize
+      token-uri: https://github.com/login/oauth/access_token
+      user-info: https://api.github.com/user

--- a/be/src/main/resources/auth/auth.yml
+++ b/be/src/main/resources/auth/auth.yml
@@ -10,3 +10,6 @@ oauth:
       authorization-uri: https://github.com/login/oauth/authorize
       token-uri: https://github.com/login/oauth/access_token
       user-info: https://api.github.com/user
+
+jwt:
+  secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
### Description

- github 로그인 구현

API : `GET /api/login/token?code=` 
- 클라이언트 측에서 authorization code를 보내면, json 응답 (body에 accessToken 담아서 보낸다)


응답 json

```json
{
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
    "name": "kukim",
    "email": null,
    "avatarUrl": null
}
```


- 로그인하지 않은 유저에 대한 다른 페이지 인증 구현 X