### PR TITLE
[FE] Avatar, Input, ListContainer, Button 컴포넌트 및 Template 작업

### DIFF
--- a/fe/src/components/common/Avatar.tsx
+++ b/fe/src/components/common/Avatar.tsx
@@ -13,6 +13,7 @@ function Avatar({ size, imgSource }: { size: AvatarTemplateType; imgSource: stri
 const AVATAR_STYLES = {
   BACKGROUND_COLOR: COLOR.GREY[300],
   BORDER_RADIUS: 50,
+  BORDER_COLOR: COLOR.GREY[300],
 };
 
 const Div = styled.div<{ size: AvatarTemplateType }>`
@@ -21,6 +22,7 @@ const Div = styled.div<{ size: AvatarTemplateType }>`
   height: ${({ size }) => SIZE.AVATAR[size]}px;
   overflow: hidden;
   border-radius: ${AVATAR_STYLES.BORDER_RADIUS}%;
+  border: 1px solid ${AVATAR_STYLES.BORDER_COLOR};
 `;
 
 type AvatarTemplateType = keyof typeof SIZE.AVATAR;

--- a/fe/src/components/common/Avatar.tsx
+++ b/fe/src/components/common/Avatar.tsx
@@ -1,0 +1,19 @@
+import { COLOR } from 'styles/color';
+
+function Avatar({ size, imgSource }: { size: '44px' | '20px'; imgSource: string }) {
+  return (
+    <div
+      style={{
+        backgroundColor: COLOR.GREY[300],
+        borderRadius: '50%',
+        overflow: 'hidden',
+        width: size,
+        height: size,
+      }}
+    >
+      <img src={imgSource} alt="회원 아바타 이미지" width="100%" height="100%" />
+    </div>
+  );
+}
+
+export default Avatar;

--- a/fe/src/components/common/Avatar.tsx
+++ b/fe/src/components/common/Avatar.tsx
@@ -1,14 +1,19 @@
 import { COLOR } from 'styles/color';
 
-function Avatar({ size, imgSource }: { size: '44px' | '20px'; imgSource: string }) {
+const AVATAR_SIZE = {
+  large: '44px',
+  small: '20px',
+};
+
+function Avatar({ size, imgSource }: { size: 'large' | 'small'; imgSource: string }) {
   return (
     <div
       style={{
         backgroundColor: COLOR.GREY[300],
         borderRadius: '50%',
         overflow: 'hidden',
-        width: size,
-        height: size,
+        width: AVATAR_SIZE[size],
+        height: AVATAR_SIZE[size],
       }}
     >
       <img src={imgSource} alt="회원 아바타 이미지" width="100%" height="100%" />

--- a/fe/src/components/common/Avatar.tsx
+++ b/fe/src/components/common/Avatar.tsx
@@ -1,24 +1,28 @@
+import styled from 'styled-components';
 import { COLOR } from 'styles/color';
+import SIZE from 'styles/size';
 
-const AVATAR_SIZE = {
-  large: '44px',
-  small: '20px',
-};
-
-function Avatar({ size, imgSource }: { size: 'large' | 'small'; imgSource: string }) {
+function Avatar({ size, imgSource }: { size: AvatarTemplateType; imgSource: string }) {
   return (
-    <div
-      style={{
-        backgroundColor: COLOR.GREY[300],
-        borderRadius: '50%',
-        overflow: 'hidden',
-        width: AVATAR_SIZE[size],
-        height: AVATAR_SIZE[size],
-      }}
-    >
+    <Div size={size}>
       <img src={imgSource} alt="회원 아바타 이미지" width="100%" height="100%" />
-    </div>
+    </Div>
   );
 }
+
+const AVATAR_STYLES = {
+  BACKGROUND_COLOR: COLOR.GREY[300],
+  BORDER_RADIUS: 50,
+};
+
+const Div = styled.div<{ size: AvatarTemplateType }>`
+  background-color: ${AVATAR_STYLES.BACKGROUND_COLOR};
+  width: ${({ size }) => SIZE.AVATAR[size]}px;
+  height: ${({ size }) => SIZE.AVATAR[size]}px;
+  overflow: hidden;
+  border-radius: ${AVATAR_STYLES.BORDER_RADIUS}%;
+`;
+
+type AvatarTemplateType = keyof typeof SIZE.AVATAR;
 
 export default Avatar;

--- a/fe/src/components/common/Button.tsx
+++ b/fe/src/components/common/Button.tsx
@@ -1,0 +1,200 @@
+import styled, { css } from 'styled-components';
+import { COLOR } from 'styles/color';
+import FONT from 'styles/font';
+
+const BUTTON_STYLES = {
+  LARGE: {
+    SIZE: {
+      WIDTH: 240,
+      HEIGHT: 64,
+    },
+    FONT_STYLE: {
+      SIZE: FONT.SIZE.MEDIUM,
+      COLOR: COLOR.WHITE,
+      WEIGHT: FONT.WEIGHT.BOLD,
+    },
+    BORDER_STYLE: `
+      border-radius: 20px;
+      border: 0;
+    `,
+  },
+  SMALL_STANDARD: {
+    SIZE: {
+      WIDTH: 120,
+      HEIGHT: 40,
+    },
+    FONT_STYLE: {
+      SIZE: FONT.SIZE.X_SMALL,
+      COLOR: COLOR.WHITE,
+      WEIGHT: FONT.WEIGHT.BOLD,
+    },
+    BORDER_STYLE: `
+      border-radius: 20px;
+      border: 0;
+    `,
+  },
+  SMALL_SECONDARY: {
+    SIZE: {
+      WIDTH: 120,
+      HEIGHT: 40,
+    },
+    FONT_STYLE: {
+      SIZE: FONT.SIZE.X_SMALL,
+      COLOR: COLOR.BLUE[200],
+      WEIGHT: FONT.WEIGHT.BOLD,
+    },
+    BORDER_STYLE: `
+      border-radius: 11px;
+      border: 0;
+    `,
+  },
+  MEDIUM_STANDARD: {
+    SIZE: {
+      WIDTH: 240,
+      HEIGHT: 56,
+    },
+    FONT_STYLE: {
+      SIZE: FONT.SIZE.MEDIUM,
+      COLOR: COLOR.WHITE,
+      WEIGHT: FONT.WEIGHT.BOLD,
+    },
+    BORDER_STYLE: `
+      border-radius: 20px;
+      border: 0;
+    `,
+  },
+  MEDIUM_TEXT: {
+    SIZE: {
+      WIDTH: 87,
+      HEIGHT: 32,
+    },
+    FONT_STYLE: {
+      SIZE: FONT.SIZE.MEDIUM,
+      COLOR: COLOR.GREY[500],
+      WEIGHT: FONT.WEIGHT.BOLD,
+    },
+    BORDER_STYLE: `
+      border: 0;
+    `,
+  },
+  SMALL_TEXT: {
+    SIZE: {
+      WIDTH: 70,
+      HEIGHT: 32,
+    },
+    FONT_STYLE: {
+      SIZE: FONT.SIZE.X_SMALL,
+      COLOR: COLOR.GREY[500],
+      WEIGHT: FONT.WEIGHT.BOLD,
+    },
+    BORDER_STYLE: `
+      border: 0;
+    `,
+  },
+};
+
+function Button({
+  templateStyle,
+  onClick,
+  children,
+  disabled,
+  width = `${BUTTON_STYLES[templateStyle].SIZE.WIDTH}px`,
+  height = `${BUTTON_STYLES[templateStyle].SIZE.HEIGHT}px`,
+  borderStyle = BUTTON_STYLES[templateStyle].BORDER_STYLE,
+  fontStyles = {
+    fontSize: BUTTON_STYLES[templateStyle].FONT_STYLE.SIZE,
+    fontColor: { initial: BUTTON_STYLES[templateStyle].FONT_STYLE.COLOR },
+    fontWeight: BUTTON_STYLES[templateStyle].FONT_STYLE.WEIGHT,
+  },
+  backgroundColor,
+}: ButtonProps) {
+  return (
+    <StyledButton
+      className="ellipsis"
+      onClick={onClick}
+      disabled={disabled}
+      width={width}
+      height={height}
+      borderStyle={borderStyle}
+      fontSize={fontStyles.fontSize}
+      fontWeight={fontStyles.fontWeight}
+      fontColor={fontStyles.fontColor}
+      backgroundColor={backgroundColor}
+    >
+      {children}
+    </StyledButton>
+  );
+}
+
+export default Button;
+
+const StyledButton = styled.button<{
+  width: string;
+  height: string;
+  borderStyle?: string;
+  fontSize?: string;
+  fontColor?: FontColors;
+  fontWeight?: number;
+  backgroundColor: BackGroundColors;
+}>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  ${({ borderStyle }) => css` ${borderStyle}}`};
+  background-color: ${({ backgroundColor }) => backgroundColor.initial};
+  font-size: ${({ fontSize }) => fontSize};
+  font-weight: ${({ fontWeight }) => fontWeight};
+  color: ${({ fontColor }) => fontColor?.initial};
+
+  &:not(:disabled):hover {
+    background-color: ${({ backgroundColor }) => backgroundColor.hover};
+    color: ${({ fontColor }) => fontColor?.hover};
+  }
+
+  &:focus {
+    background-color: ${({ backgroundColor }) => backgroundColor.focus};
+  }
+
+  &:active {
+    color: ${({ fontColor }) => fontColor?.active};
+  }
+
+  &:disabled {
+    background-color: ${({ backgroundColor }) => backgroundColor.disabled};
+    color: ${({ fontColor }) => fontColor?.disabled};
+    cursor: default;
+  }
+`;
+
+type TemplateStyleType = keyof typeof BUTTON_STYLES;
+
+interface ButtonProps {
+  onClick?: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+  width?: string;
+  height?: string;
+  borderStyle?: string;
+  templateStyle: TemplateStyleType;
+  fontStyles?: FontStyles;
+  backgroundColor: BackGroundColors;
+}
+
+interface FontColors {
+  initial: string;
+  active?: string;
+  hover?: string;
+  disabled?: string;
+}
+
+interface FontStyles {
+  fontSize?: string;
+  fontColor?: FontColors;
+  fontWeight?: number;
+}
+
+interface BackGroundColors {
+  initial: string;
+  hover?: string;
+  focus?: string;
+  disabled?: string;
+}

--- a/fe/src/components/common/Button.tsx
+++ b/fe/src/components/common/Button.tsx
@@ -2,6 +2,41 @@ import styled, { css } from 'styled-components';
 import { COLOR } from 'styles/color';
 import FONT from 'styles/font';
 
+function Button({
+  template,
+  onClick,
+  children,
+  disabled,
+  width = `${BUTTON_STYLES[template].SIZE.WIDTH}px`,
+  height = `${BUTTON_STYLES[template].SIZE.HEIGHT}px`,
+  borderStyle = BUTTON_STYLES[template].BORDER_STYLE,
+  fontStyles = {
+    fontSize: BUTTON_STYLES[template].FONT_STYLE.SIZE,
+    fontColor: { initial: BUTTON_STYLES[template].FONT_STYLE.COLOR },
+    fontWeight: BUTTON_STYLES[template].FONT_STYLE.WEIGHT,
+  },
+  backgroundColor,
+}: ButtonProps) {
+  return (
+    <StyledButton
+      className="ellipsis"
+      onClick={onClick}
+      disabled={disabled}
+      width={width}
+      height={height}
+      borderStyle={borderStyle}
+      fontSize={fontStyles.fontSize}
+      fontWeight={fontStyles.fontWeight}
+      fontColor={fontStyles.fontColor}
+      backgroundColor={backgroundColor}
+    >
+      {children}
+    </StyledButton>
+  );
+}
+
+export default Button;
+
 const BUTTON_STYLES = {
   LARGE: {
     SIZE: {
@@ -93,41 +128,6 @@ const BUTTON_STYLES = {
   },
 };
 
-function Button({
-  templateStyle,
-  onClick,
-  children,
-  disabled,
-  width = `${BUTTON_STYLES[templateStyle].SIZE.WIDTH}px`,
-  height = `${BUTTON_STYLES[templateStyle].SIZE.HEIGHT}px`,
-  borderStyle = BUTTON_STYLES[templateStyle].BORDER_STYLE,
-  fontStyles = {
-    fontSize: BUTTON_STYLES[templateStyle].FONT_STYLE.SIZE,
-    fontColor: { initial: BUTTON_STYLES[templateStyle].FONT_STYLE.COLOR },
-    fontWeight: BUTTON_STYLES[templateStyle].FONT_STYLE.WEIGHT,
-  },
-  backgroundColor,
-}: ButtonProps) {
-  return (
-    <StyledButton
-      className="ellipsis"
-      onClick={onClick}
-      disabled={disabled}
-      width={width}
-      height={height}
-      borderStyle={borderStyle}
-      fontSize={fontStyles.fontSize}
-      fontWeight={fontStyles.fontWeight}
-      fontColor={fontStyles.fontColor}
-      backgroundColor={backgroundColor}
-    >
-      {children}
-    </StyledButton>
-  );
-}
-
-export default Button;
-
 const StyledButton = styled.button<{
   width: string;
   height: string;
@@ -165,7 +165,7 @@ const StyledButton = styled.button<{
   }
 `;
 
-type TemplateStyleType = keyof typeof BUTTON_STYLES;
+type TemplateType = keyof typeof BUTTON_STYLES;
 
 interface ButtonProps {
   onClick?: () => void;
@@ -174,7 +174,7 @@ interface ButtonProps {
   width?: string;
   height?: string;
   borderStyle?: string;
-  templateStyle: TemplateStyleType;
+  template: TemplateType;
   fontStyles?: FontStyles;
   backgroundColor: BackGroundColors;
 }

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -13,39 +13,82 @@ const Wrapper = styled.div<{
   background-color: ${({ isFocused }) => (isFocused ? COLOR.WHITE : COLOR.GREY[200])};
   border: 1px solid ${({ isFocused }) => (isFocused ? COLOR.BLACK : 'transparent')};
 
-  ${({ templateStyle }) => {
-    let borderStyle;
+  ${({ templateStyle, isFocused }) => {
+    let styles;
     switch (templateStyle) {
       case 'small':
-        borderStyle = css`
+        styles = css`
+          padding-left: 24px;
           border-radius: 11px;
         `;
         break;
       case 'large':
-        borderStyle = css`
+        styles = css`
+          ${isFocused
+            ? css`
+                padding: 8px 24px;
+              `
+            : css`
+                padding: 18px 24px;
+              `}
+          flex-direction: column;
           border-radius: 16px;
         `;
         break;
       case 'medium':
-        borderStyle = css`
+        styles = css`
+          ${isFocused
+            ? css`
+                padding: 4px 24px;
+              `
+            : css`
+                padding: 14px 24px;
+              `}
+          flex-direction: column;
           border-radius: 14px;
         `;
         break;
       default:
         break;
     }
-    return borderStyle;
+    return styles;
   }};
 
   .input-label {
-    ${({ templateStyle, isFocused }) => {
-      let inputLabelStyle = ``;
+    ${({ templateStyle, isFocused, size }) => {
+      let inputLabelStyle;
       switch (templateStyle) {
         case 'small':
+          inputLabelStyle = css`
+            width: 80px;
+            line-height: ${size.height};
+            margin-right: 8px;
+            ${isFocused
+              ? css`
+                  font-size: 12px;
+                  color: ${COLOR.GREY[400]};
+                `
+              : css`
+                  font-size: 16px;
+                  color: ${COLOR.GREY[500]};
+                `};
+          `;
           break;
         case 'large':
         case 'medium':
-          inputLabelStyle += isFocused ? `display: block;` : `display: none`;
+          inputLabelStyle = css`
+            font-size: 12px;
+            height: 20px;
+            line-height: 20px;
+            color: ${COLOR.GREY[500]};
+            ${isFocused
+              ? css`
+                  display: block;
+                `
+              : css`
+                  display: none;
+                `}
+          `;
           break;
         default:
           break;
@@ -55,13 +98,38 @@ const Wrapper = styled.div<{
   }
 
   .input-wrap {
+    ${({ templateStyle, isFocused }) => {
+      let inputWrapStyle;
+      switch (templateStyle) {
+        case 'small':
+          inputWrapStyle = css`
+            width: calc(100% - 80px);
+          `;
+          break;
+        case 'large':
+        case 'medium':
+          inputWrapStyle = css`
+            ${isFocused
+              ? css`
+                  height: calc(100% - 20px);
+                `
+              : css`
+                  height: 100%;
+                `}
+          `;
+          break;
+        default:
+          break;
+      }
+      return inputWrapStyle;
+    }}
   }
 `;
 
 function Input({
   placeholder,
   size,
-  InputTitle = '',
+  inputLabel = '',
   inputId,
   templateStyle = 'medium',
 }: InputProps) {
@@ -73,12 +141,14 @@ function Input({
   };
   return (
     <Wrapper size={size} isFocused={isFocused} templateStyle={templateStyle}>
-      <label className="input-label" htmlFor={inputId}>
-        {InputTitle}
-      </label>
+      {inputLabel && (
+        <label className="input-label" htmlFor={inputId}>
+          {inputLabel}
+        </label>
+      )}
       <div className="input-wrap">
         <input
-          placeholder={placeholder}
+          placeholder={isFocused ? '' : placeholder}
           onChange={onChange}
           value={inputText}
           onFocus={() => setIsFocused(true)}
@@ -105,5 +175,5 @@ interface InputProps {
   size: SizeType;
   templateStyle?: TemplateStyleType;
   inputId: string;
-  InputTitle?: React.ReactNode;
+  inputLabel?: React.ReactNode;
 }

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { COLOR } from 'styles/color';
 
 const Wrapper = styled.div<{
@@ -12,6 +12,30 @@ const Wrapper = styled.div<{
   height: ${({ size }) => size.height};
   background-color: ${({ isFocused }) => (isFocused ? COLOR.WHITE : COLOR.GREY[200])};
   border: 1px solid ${({ isFocused }) => (isFocused ? COLOR.BLACK : 'transparent')};
+
+  ${({ templateStyle }) => {
+    let borderStyle;
+    switch (templateStyle) {
+      case 'small':
+        borderStyle = css`
+          border-radius: 11px;
+        `;
+        break;
+      case 'large':
+        borderStyle = css`
+          border-radius: 16px;
+        `;
+        break;
+      case 'medium':
+        borderStyle = css`
+          border-radius: 14px;
+        `;
+        break;
+      default:
+        break;
+    }
+    return borderStyle;
+  }};
 
   .input-label {
     ${({ templateStyle, isFocused }) => {

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { COLOR } from 'styles/color';
+import FONT from 'styles/font';
 
 const Wrapper = styled.div<{
   size: SizeType;
@@ -12,6 +13,7 @@ const Wrapper = styled.div<{
   height: ${({ size }) => size.height};
   background-color: ${({ isFocused }) => (isFocused ? COLOR.WHITE : COLOR.GREY[200])};
   border: 1px solid ${({ isFocused }) => (isFocused ? COLOR.BLACK : 'transparent')};
+  font-weight: ${FONT.WEIGHT.REGULAR};
 
   ${({ templateStyle, isFocused }) => {
     let styles;
@@ -69,7 +71,7 @@ const Wrapper = styled.div<{
                   color: ${COLOR.GREY[400]};
                 `
               : css`
-                  font-size: 16px;
+                  font-size: ${FONT.SIZE.SMALL};
                   color: ${COLOR.GREY[500]};
                 `};
           `;

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -4,6 +4,44 @@ import { COLOR } from 'styles/color';
 import FONT from 'styles/font';
 import SIZE from 'styles/size';
 
+function Input({
+  template = 'MEDIUM',
+  placeholder,
+  width = `${SIZE.INPUT[template].WIDTH}px`,
+  height = `${SIZE.INPUT[template].HEIGHT}px`,
+  inputLabel = '',
+  inputId,
+}: InputProps) {
+  const [isFocused, setIsFocused] = useState(false);
+  const [inputText, setInputText] = useState('');
+
+  const onChange = ({ target }: { target: HTMLInputElement }) => {
+    setInputText(target.value);
+  };
+  return (
+    <Wrapper width={width} height={height} isFocused={isFocused} template={template}>
+      {inputLabel && (
+        <label className="input-label" htmlFor={inputId}>
+          {inputLabel}
+        </label>
+      )}
+      <div className="input-wrap">
+        <input
+          placeholder={isFocused ? '' : placeholder}
+          onChange={onChange}
+          value={inputText}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          id={inputId}
+          style={{ background: 'transparent' }}
+        />
+      </div>
+    </Wrapper>
+  );
+}
+
+export default Input;
+
 const INPUT_STYLES = {
   SMALL: {
     PADDING: {
@@ -163,44 +201,6 @@ const Wrapper = styled.div<{
       template !== 'SMALL' && isFocused && INPUT_STYLES.MEDIUM.INPUT_WRAP.FOCUSED}
   }
 `;
-
-function Input({
-  template = 'MEDIUM',
-  placeholder,
-  width = `${SIZE.INPUT[template].WIDTH}px`,
-  height = `${SIZE.INPUT[template].HEIGHT}px`,
-  inputLabel = '',
-  inputId,
-}: InputProps) {
-  const [isFocused, setIsFocused] = useState(false);
-  const [inputText, setInputText] = useState('');
-
-  const onChange = ({ target }: { target: HTMLInputElement }) => {
-    setInputText(target.value);
-  };
-  return (
-    <Wrapper width={width} height={height} isFocused={isFocused} template={template}>
-      {inputLabel && (
-        <label className="input-label" htmlFor={inputId}>
-          {inputLabel}
-        </label>
-      )}
-      <div className="input-wrap">
-        <input
-          placeholder={isFocused ? '' : placeholder}
-          onChange={onChange}
-          value={inputText}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          id={inputId}
-          style={{ background: 'transparent' }}
-        />
-      </div>
-    </Wrapper>
-  );
-}
-
-export default Input;
 
 type TemplateType = keyof typeof INPUT_STYLES;
 

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { COLOR } from 'styles/color';
 import FONT from 'styles/font';
+import SIZE from 'styles/size';
 
 const INPUT_STYLES = {
   SMALL: {
@@ -92,20 +93,20 @@ const INPUT_STYLES = {
 };
 
 const Wrapper = styled.div<{
-  size: SizeType;
+  width?: string;
+  height?: string;
   isFocused: boolean;
   template: TemplateType;
 }>`
   display: flex;
-  width: ${({ size }) => size.width};
-  height: ${({ size }) => size.height};
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
   background-color: ${({ isFocused }) => (isFocused ? COLOR.WHITE : COLOR.GREY[200])};
   border: 1px solid ${({ isFocused }) => (isFocused ? COLOR.BLACK : 'transparent')};
   font-weight: ${FONT.WEIGHT.REGULAR};
 
-  ${({ template }) => {
-    return INPUT_STYLES[template].PADDING.INITIAL, INPUT_STYLES[template].BORDER;
-  }};
+  ${({ template }) => INPUT_STYLES[template].PADDING.INITIAL};
+  ${({ template }) => INPUT_STYLES[template].BORDER};
 
   /* template MEDIUM, LARGE style */
   ${({ template }) => template !== 'SMALL' && INPUT_STYLES[template].FLEX}
@@ -114,14 +115,15 @@ const Wrapper = styled.div<{
 
   .input-label {
     /* template SMALL style */
+    width: ${({ template }) => template === 'SMALL' && INPUT_STYLES[template].LABEL.WIDTH}px;
+    line-height: ${({ height }) => height};
+    ${({ template }) => template === 'SMALL' && INPUT_STYLES[template].LABEL.MARGIN}
     ${({ template }) =>
       template === 'SMALL' &&
-      (INPUT_STYLES[template].LABEL.WIDTH,
-      INPUT_STYLES[template].LABEL.MARGIN,
       css`
         font-size: ${INPUT_STYLES[template].LABEL.FONT_STYLE.INITIAL.SIZE};
         color: ${INPUT_STYLES[template].LABEL.FONT_STYLE.INITIAL.COLOR};
-      `)}
+      `}
 
     ${({ isFocused, template }) =>
       template === 'SMALL' &&
@@ -132,15 +134,15 @@ const Wrapper = styled.div<{
       `}
 
     /* template MEDIUM, LARGE style */
+    height: ${({ template }) => template !== 'SMALL' && INPUT_STYLES.MEDIUM.LABEL.HEIGHT}px;
     ${({ template }) =>
       template !== 'SMALL' &&
-      (INPUT_STYLES.MEDIUM.LABEL.HEIGHT,
       css`
         font-size: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.SIZE};
         color: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.COLOR};
-        line-height: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.LINE_HEIGHT};
+        line-height: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.LINE_HEIGHT}px;
         display: ${INPUT_STYLES.MEDIUM.LABEL.DISPLAY};
-      `)}
+      `}
 
     ${({ isFocused, template }) =>
       template !== 'SMALL' &&
@@ -162,7 +164,14 @@ const Wrapper = styled.div<{
   }
 `;
 
-function Input({ placeholder, size, inputLabel = '', inputId, template = 'MEDIUM' }: InputProps) {
+function Input({
+  template = 'MEDIUM',
+  placeholder,
+  width = `${SIZE.INPUT[template].WIDTH}px`,
+  height = `${SIZE.INPUT[template].HEIGHT}px`,
+  inputLabel = '',
+  inputId,
+}: InputProps) {
   const [isFocused, setIsFocused] = useState(false);
   const [inputText, setInputText] = useState('');
 
@@ -170,7 +179,7 @@ function Input({ placeholder, size, inputLabel = '', inputId, template = 'MEDIUM
     setInputText(target.value);
   };
   return (
-    <Wrapper size={size} isFocused={isFocused} template={template}>
+    <Wrapper width={width} height={height} isFocused={isFocused} template={template}>
       {inputLabel && (
         <label className="input-label" htmlFor={inputId}>
           {inputLabel}
@@ -195,14 +204,10 @@ export default Input;
 
 type TemplateType = keyof typeof INPUT_STYLES;
 
-interface SizeType {
-  width: string;
-  height: string;
-}
-
 interface InputProps {
   placeholder: string;
-  size: SizeType;
+  width?: string;
+  height?: string;
   template?: TemplateType;
   inputId: string;
   inputLabel?: React.ReactNode;

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { COLOR } from 'styles/color';
+
+const Wrapper = styled.div<{
+  size: SizeType;
+  isFocused: boolean;
+  templateStyle: TemplateStyleType;
+}>`
+  display: flex;
+  width: ${({ size }) => size.width};
+  height: ${({ size }) => size.height};
+  background-color: ${({ isFocused }) => (isFocused ? COLOR.WHITE : COLOR.GREY[200])};
+  border: 1px solid ${({ isFocused }) => (isFocused ? COLOR.BLACK : 'transparent')};
+
+  .input-label {
+    ${({ templateStyle, isFocused }) => {
+      let inputLabelStyle = ``;
+      switch (templateStyle) {
+        case 'small':
+          break;
+        case 'large':
+        case 'medium':
+          inputLabelStyle += isFocused ? `display: block;` : `display: none`;
+          break;
+        default:
+          break;
+      }
+      return inputLabelStyle;
+    }}
+  }
+
+  .input-wrap {
+  }
+`;
+
+function Input({
+  placeholder,
+  size,
+  InputTitle = '',
+  inputId,
+  templateStyle = 'medium',
+}: InputProps) {
+  const [isFocused, setIsFocused] = useState(false);
+  const [inputText, setInputText] = useState('');
+
+  const onChange = ({ target }: { target: HTMLInputElement }) => {
+    setInputText(target.value);
+  };
+  return (
+    <Wrapper size={size} isFocused={isFocused} templateStyle={templateStyle}>
+      <label className="input-label" htmlFor={inputId}>
+        {InputTitle}
+      </label>
+      <div className="input-wrap">
+        <input
+          placeholder={placeholder}
+          onChange={onChange}
+          value={inputText}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          id={inputId}
+          style={{ background: 'transparent' }}
+        />
+      </div>
+    </Wrapper>
+  );
+}
+
+export default Input;
+
+interface SizeType {
+  width: string;
+  height: string;
+}
+
+type TemplateStyleType = 'small' | 'large' | 'medium';
+
+interface InputProps {
+  placeholder: string;
+  size: SizeType;
+  templateStyle?: TemplateStyleType;
+  inputId: string;
+  InputTitle?: React.ReactNode;
+}

--- a/fe/src/components/common/Input.tsx
+++ b/fe/src/components/common/Input.tsx
@@ -3,10 +3,98 @@ import styled, { css } from 'styled-components';
 import { COLOR } from 'styles/color';
 import FONT from 'styles/font';
 
+const INPUT_STYLES = {
+  SMALL: {
+    PADDING: {
+      INITIAL: css`
+        padding-left: 24px;
+      `,
+    },
+    BORDER: css`
+      border-radius: 11px;
+    `,
+    LABEL: {
+      WIDTH: 80,
+      MARGIN: css`
+        margin-right: 8px;
+      `,
+      FONT_STYLE: {
+        INITIAL: {
+          SIZE: FONT.SIZE.X_SMALL,
+          COLOR: COLOR.GREY[400],
+        },
+        FOCUSED: {
+          SIZE: FONT.SIZE.SMALL,
+          COLOR: COLOR.GREY[500],
+        },
+      },
+    },
+    INPUT_WRAP: {
+      INITIAL: css`
+        width: calc(100% - 80px);
+      `,
+    },
+  },
+  MEDIUM: {
+    PADDING: {
+      INITIAL: css`
+        padding: 14px 24px;
+      `,
+      FOCUSED: css`
+        padding: 4px 24px;
+      `,
+    },
+    BORDER: css`
+      border-radius: 14px;
+    `,
+    FLEX: css`
+      flex-direction: column;
+    `,
+    LABEL: {
+      HEIGHT: 20,
+      DISPLAY: 'none',
+      FONT_STYLE: {
+        INITIAL: {
+          LINE_HEIGHT: 20,
+          SIZE: FONT.SIZE.X_SMALL,
+          COLOR: COLOR.GREY[500],
+        },
+        FOCUSED: {
+          DISPLAY: 'block',
+        },
+      },
+    },
+    INPUT_WRAP: {
+      INITIAL: css`
+        height: 100%;
+      `,
+      FOCUSED: css`
+        height: calc(100% - 20px);
+      `,
+    },
+  },
+  LARGE: {
+    PADDING: {
+      INITIAL: css`
+        padding: 14px 24px;
+      `,
+      FOCUSED: css`
+        padding: 8px 24px;
+      `,
+    },
+    BORDER: css`
+      border-radius: 16px;
+    `,
+    FLEX: css`
+      flex-direction: column;
+    `,
+  },
+};
+
 const Wrapper = styled.div<{
   size: SizeType;
   isFocused: boolean;
-  templateStyle: TemplateStyleType;
+  template: TemplateType;
 }>`
   display: flex;
   width: ${({ size }) => size.width};
@@ -15,126 +103,66 @@ const Wrapper = styled.div<{
   border: 1px solid ${({ isFocused }) => (isFocused ? COLOR.BLACK : 'transparent')};
   font-weight: ${FONT.WEIGHT.REGULAR};
 
-  ${({ templateStyle, isFocused }) => {
-    let styles;
-    switch (templateStyle) {
-      case 'small':
-        styles = css`
-          padding-left: 24px;
-          border-radius: 11px;
-        `;
-        break;
-      case 'large':
-        styles = css`
-          ${isFocused
-            ? css`
-                padding: 8px 24px;
-              `
-            : css`
-                padding: 18px 24px;
-              `}
-          flex-direction: column;
-          border-radius: 16px;
-        `;
-        break;
-      case 'medium':
-        styles = css`
-          ${isFocused
-            ? css`
-                padding: 4px 24px;
-              `
-            : css`
-                padding: 14px 24px;
-              `}
-          flex-direction: column;
-          border-radius: 14px;
-        `;
-        break;
-      default:
-        break;
-    }
-    return styles;
+  ${({ template }) => {
+    return INPUT_STYLES[template].PADDING.INITIAL, INPUT_STYLES[template].BORDER;
   }};
 
+  /* template MEDIUM, LARGE style */
+  ${({ template }) => template !== 'SMALL' && INPUT_STYLES[template].FLEX}
+  ${({ isFocused, template }) =>
+    template !== 'SMALL' && isFocused && INPUT_STYLES[template].PADDING.FOCUSED}
+
   .input-label {
-    ${({ templateStyle, isFocused, size }) => {
-      let inputLabelStyle;
-      switch (templateStyle) {
-        case 'small':
-          inputLabelStyle = css`
-            width: 80px;
-            line-height: ${size.height};
-            margin-right: 8px;
-            ${isFocused
-              ? css`
-                  font-size: 12px;
-                  color: ${COLOR.GREY[400]};
-                `
-              : css`
-                  font-size: ${FONT.SIZE.SMALL};
-                  color: ${COLOR.GREY[500]};
-                `};
-          `;
-          break;
-        case 'large':
-        case 'medium':
-          inputLabelStyle = css`
-            font-size: 12px;
-            height: 20px;
-            line-height: 20px;
-            color: ${COLOR.GREY[500]};
-            ${isFocused
-              ? css`
-                  display: block;
-                `
-              : css`
-                  display: none;
-                `}
-          `;
-          break;
-        default:
-          break;
-      }
-      return inputLabelStyle;
-    }}
+    /* template SMALL style */
+    ${({ template }) =>
+      template === 'SMALL' &&
+      (INPUT_STYLES[template].LABEL.WIDTH,
+      INPUT_STYLES[template].LABEL.MARGIN,
+      css`
+        font-size: ${INPUT_STYLES[template].LABEL.FONT_STYLE.INITIAL.SIZE};
+        color: ${INPUT_STYLES[template].LABEL.FONT_STYLE.INITIAL.COLOR};
+      `)}
+
+    ${({ isFocused, template }) =>
+      template === 'SMALL' &&
+      isFocused &&
+      css`
+        font-size: ${INPUT_STYLES[template].LABEL.FONT_STYLE.FOCUSED.SIZE};
+        color: ${INPUT_STYLES[template].LABEL.FONT_STYLE.FOCUSED.COLOR};
+      `}
+
+    /* template MEDIUM, LARGE style */
+    ${({ template }) =>
+      template !== 'SMALL' &&
+      (INPUT_STYLES.MEDIUM.LABEL.HEIGHT,
+      css`
+        font-size: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.SIZE};
+        color: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.COLOR};
+        line-height: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.INITIAL.LINE_HEIGHT};
+        display: ${INPUT_STYLES.MEDIUM.LABEL.DISPLAY};
+      `)}
+
+    ${({ isFocused, template }) =>
+      template !== 'SMALL' &&
+      isFocused &&
+      css`
+        display: ${INPUT_STYLES.MEDIUM.LABEL.FONT_STYLE.FOCUSED.DISPLAY};
+      `}
   }
 
   .input-wrap {
-    ${({ templateStyle, isFocused }) => {
-      let inputWrapStyle;
-      switch (templateStyle) {
-        case 'small':
-          inputWrapStyle = css`
-            width: calc(100% - 80px);
-          `;
-          break;
-        case 'large':
-        case 'medium':
-          inputWrapStyle = css`
-            ${isFocused
-              ? css`
-                  height: calc(100% - 20px);
-                `
-              : css`
-                  height: 100%;
-                `}
-          `;
-          break;
-        default:
-          break;
-      }
-      return inputWrapStyle;
-    }}
+    /* template SMALL style */
+    ${({ template }) => template === 'SMALL' && INPUT_STYLES.SMALL.INPUT_WRAP.INITIAL}
+
+    /* template MEDIUM, LARGE style */
+    ${({ template }) => template !== 'SMALL' && INPUT_STYLES.MEDIUM.INPUT_WRAP.INITIAL}
+
+    ${({ isFocused, template }) =>
+      template !== 'SMALL' && isFocused && INPUT_STYLES.MEDIUM.INPUT_WRAP.FOCUSED}
   }
 `;
 
-function Input({
-  placeholder,
-  size,
-  inputLabel = '',
-  inputId,
-  templateStyle = 'medium',
-}: InputProps) {
+function Input({ placeholder, size, inputLabel = '', inputId, template = 'MEDIUM' }: InputProps) {
   const [isFocused, setIsFocused] = useState(false);
   const [inputText, setInputText] = useState('');
 
@@ -142,7 +170,7 @@ function Input({
     setInputText(target.value);
   };
   return (
-    <Wrapper size={size} isFocused={isFocused} templateStyle={templateStyle}>
+    <Wrapper size={size} isFocused={isFocused} template={template}>
       {inputLabel && (
         <label className="input-label" htmlFor={inputId}>
           {inputLabel}
@@ -165,17 +193,17 @@ function Input({
 
 export default Input;
 
+type TemplateType = keyof typeof INPUT_STYLES;
+
 interface SizeType {
   width: string;
   height: string;
 }
 
-type TemplateStyleType = 'small' | 'large' | 'medium';
-
 interface InputProps {
   placeholder: string;
   size: SizeType;
-  templateStyle?: TemplateStyleType;
+  template?: TemplateType;
   inputId: string;
   inputLabel?: React.ReactNode;
 }

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+import { COLOR } from 'styles/color';
+
+const LIST_CONTAINER_SIZE_PIXEL = {
+  WIDTH: 1280,
+  PADDING_LEFT: 32,
+  BORDER_RADIUS: 16,
+  HEADER: {
+    HEIGHT: 64,
+    PADDING_TOP: 18,
+    FONT_SIZE: 16,
+  },
+  BODY: {
+    ITEM_HEIGHT: 100,
+    PADDING_TOP: 16,
+  },
+};
+
+const Wrapper = styled.div`
+  width: ${LIST_CONTAINER_SIZE_PIXEL}px;
+  border-radius: ${LIST_CONTAINER_SIZE_PIXEL.BORDER_RADIUS}px;
+  border: 1px solid ${COLOR.GREY[500]};
+  padding: 0 ${LIST_CONTAINER_SIZE_PIXEL.PADDING_LEFT}px;
+
+  .list-header {
+    width: 100%;
+    height: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.HEIGHT}px;
+    background-color: ${COLOR.GREY[100]};
+    font-size: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.FONT_SIZE}px;
+    padding: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.PADDING_TOP}px 0;
+  }
+
+  .list-body {
+    width: 100%;
+    background-color: ${COLOR.WHITE};
+  }
+
+  .list-body-item {
+    height: ${LIST_CONTAINER_SIZE_PIXEL.BODY.ITEM_HEIGHT};
+    padding: ${LIST_CONTAINER_SIZE_PIXEL.BODY.PADDING_TOP}px 0;
+  }
+`;
+
+function ListContainer({ headerItem, bodyItems }: ListContainerProps) {
+  return (
+    <Wrapper>
+      <div className="list-header">{headerItem}</div>
+      <div className="list-body">
+        {bodyItems.map((bodyItem) => (
+          <div className="list-body-item">{bodyItem}</div>
+        ))}
+      </div>
+    </Wrapper>
+  );
+}
+
+export default ListContainer;
+
+interface ListContainerProps {
+  headerItem: React.ReactNode;
+  bodyItems: React.ReactNode[];
+}

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -24,6 +24,8 @@ const Wrapper = styled.div`
   .list-header {
     width: 100%;
     height: ${SIZE.LIST_CONTAINER.HEADER.HEIGHT}px;
+    display: flex;
+    align-items: center;
     background-color: ${COLOR.GREY[100]};
     font-size: ${SIZE.LIST_CONTAINER.HEADER.FONT_SIZE}px;
     padding: ${SIZE.LIST_CONTAINER.HEADER.PADDING_TOP}px ${SIZE.LIST_CONTAINER.PADDING_LEFT}px;
@@ -34,7 +36,8 @@ const Wrapper = styled.div`
     width: 100%;
     background-color: ${COLOR.WHITE};
 
-    &:nth-child(n) {
+    /* children div tag로 작성 */
+    div:nth-child(n) {
       height: ${SIZE.LIST_CONTAINER.BODY.ITEM_HEIGHT};
       padding: ${SIZE.LIST_CONTAINER.BODY.PADDING_TOP}px ${SIZE.LIST_CONTAINER.PADDING_LEFT}px;
 

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -2,9 +2,13 @@ import styled from 'styled-components';
 import { COLOR } from 'styles/color';
 import SIZE from 'styles/size';
 
-function ListContainer({ headerItem, children }: ListContainerProps) {
+function ListContainer({
+  headerItem,
+  children,
+  width = `${SIZE.LIST_CONTAINER.WIDTH}px`,
+}: ListContainerProps) {
   return (
-    <Wrapper>
+    <Wrapper width={width}>
       <div className="list-header">{headerItem}</div>
       <div className="list-body">{children}</div>
     </Wrapper>
@@ -15,8 +19,8 @@ export default ListContainer;
 
 const BORDER_COLOR = COLOR.GREY[300];
 
-const Wrapper = styled.div`
-  width: ${SIZE.LIST_CONTAINER.WIDTH}px;
+const Wrapper = styled.div<{ width: string }>`
+  width: ${({ width }) => width};
   border-radius: ${SIZE.LIST_CONTAINER.BORDER_RADIUS}px;
   border: 1px solid ${BORDER_COLOR};
   overflow: hidden;
@@ -48,6 +52,7 @@ const Wrapper = styled.div`
   }
 `;
 interface ListContainerProps {
+  width?: string;
   headerItem: React.ReactNode;
   children: React.ReactNode;
 }

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -2,6 +2,17 @@ import styled from 'styled-components';
 import { COLOR } from 'styles/color';
 import SIZE from 'styles/size';
 
+function ListContainer({ headerItem, children }: ListContainerProps) {
+  return (
+    <Wrapper>
+      <div className="list-header">{headerItem}</div>
+      <div className="list-body">{children}</div>
+    </Wrapper>
+  );
+}
+
+export default ListContainer;
+
 const BORDER_COLOR = COLOR.GREY[300];
 
 const Wrapper = styled.div`
@@ -33,18 +44,6 @@ const Wrapper = styled.div`
     }
   }
 `;
-
-function ListContainer({ headerItem, children }: ListContainerProps) {
-  return (
-    <Wrapper>
-      <div className="list-header">{headerItem}</div>
-      <div className="list-body">{children}</div>
-    </Wrapper>
-  );
-}
-
-export default ListContainer;
-
 interface ListContainerProps {
   headerItem: React.ReactNode;
   children: React.ReactNode;

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -16,40 +16,45 @@ const LIST_CONTAINER_SIZE_PIXEL = {
   },
 };
 
+const BORDER_COLOR = COLOR.GREY[300];
+
 const Wrapper = styled.div`
-  width: ${LIST_CONTAINER_SIZE_PIXEL}px;
+  width: ${LIST_CONTAINER_SIZE_PIXEL.WIDTH}px;
   border-radius: ${LIST_CONTAINER_SIZE_PIXEL.BORDER_RADIUS}px;
-  border: 1px solid ${COLOR.GREY[500]};
-  padding: 0 ${LIST_CONTAINER_SIZE_PIXEL.PADDING_LEFT}px;
+  border: 1px solid ${BORDER_COLOR};
+  overflow: hidden;
 
   .list-header {
     width: 100%;
     height: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.HEIGHT}px;
     background-color: ${COLOR.GREY[100]};
     font-size: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.FONT_SIZE}px;
-    padding: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.PADDING_TOP}px 0;
+    padding: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.PADDING_TOP}px
+      ${LIST_CONTAINER_SIZE_PIXEL.PADDING_LEFT}px;
+    border-bottom: 1px solid ${BORDER_COLOR};
   }
 
   .list-body {
     width: 100%;
     background-color: ${COLOR.WHITE};
-  }
 
-  .list-body-item {
-    height: ${LIST_CONTAINER_SIZE_PIXEL.BODY.ITEM_HEIGHT};
-    padding: ${LIST_CONTAINER_SIZE_PIXEL.BODY.PADDING_TOP}px 0;
+    &:nth-child(n) {
+      height: ${LIST_CONTAINER_SIZE_PIXEL.BODY.ITEM_HEIGHT};
+      padding: ${LIST_CONTAINER_SIZE_PIXEL.BODY.PADDING_TOP}px
+        ${LIST_CONTAINER_SIZE_PIXEL.PADDING_LEFT}px;
+
+      &:not(:last-child) {
+        border-bottom: 1px solid ${BORDER_COLOR};
+      }
+    }
   }
 `;
 
-function ListContainer({ headerItem, bodyItems }: ListContainerProps) {
+function ListContainer({ headerItem, children }: ListContainerProps) {
   return (
     <Wrapper>
       <div className="list-header">{headerItem}</div>
-      <div className="list-body">
-        {bodyItems.map((bodyItem) => (
-          <div className="list-body-item">{bodyItem}</div>
-        ))}
-      </div>
+      <div className="list-body">{children}</div>
     </Wrapper>
   );
 }
@@ -58,5 +63,5 @@ export default ListContainer;
 
 interface ListContainerProps {
   headerItem: React.ReactNode;
-  bodyItems: React.ReactNode[];
+  children: React.ReactNode;
 }

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -1,36 +1,21 @@
 import styled from 'styled-components';
 import { COLOR } from 'styles/color';
-
-const LIST_CONTAINER_SIZE_PIXEL = {
-  WIDTH: 1280,
-  PADDING_LEFT: 32,
-  BORDER_RADIUS: 16,
-  HEADER: {
-    HEIGHT: 64,
-    PADDING_TOP: 18,
-    FONT_SIZE: 16,
-  },
-  BODY: {
-    ITEM_HEIGHT: 100,
-    PADDING_TOP: 16,
-  },
-};
+import SIZE from 'styles/size';
 
 const BORDER_COLOR = COLOR.GREY[300];
 
 const Wrapper = styled.div`
-  width: ${LIST_CONTAINER_SIZE_PIXEL.WIDTH}px;
-  border-radius: ${LIST_CONTAINER_SIZE_PIXEL.BORDER_RADIUS}px;
+  width: ${SIZE.LIST_CONTAINER.WIDTH}px;
+  border-radius: ${SIZE.LIST_CONTAINER.BORDER_RADIUS}px;
   border: 1px solid ${BORDER_COLOR};
   overflow: hidden;
 
   .list-header {
     width: 100%;
-    height: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.HEIGHT}px;
+    height: ${SIZE.LIST_CONTAINER.HEADER.HEIGHT}px;
     background-color: ${COLOR.GREY[100]};
-    font-size: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.FONT_SIZE}px;
-    padding: ${LIST_CONTAINER_SIZE_PIXEL.HEADER.PADDING_TOP}px
-      ${LIST_CONTAINER_SIZE_PIXEL.PADDING_LEFT}px;
+    font-size: ${SIZE.LIST_CONTAINER.HEADER.FONT_SIZE}px;
+    padding: ${SIZE.LIST_CONTAINER.HEADER.PADDING_TOP}px ${SIZE.LIST_CONTAINER.PADDING_LEFT}px;
     border-bottom: 1px solid ${BORDER_COLOR};
   }
 
@@ -39,9 +24,8 @@ const Wrapper = styled.div`
     background-color: ${COLOR.WHITE};
 
     &:nth-child(n) {
-      height: ${LIST_CONTAINER_SIZE_PIXEL.BODY.ITEM_HEIGHT};
-      padding: ${LIST_CONTAINER_SIZE_PIXEL.BODY.PADDING_TOP}px
-        ${LIST_CONTAINER_SIZE_PIXEL.PADDING_LEFT}px;
+      height: ${SIZE.LIST_CONTAINER.BODY.ITEM_HEIGHT};
+      padding: ${SIZE.LIST_CONTAINER.BODY.PADDING_TOP}px ${SIZE.LIST_CONTAINER.PADDING_LEFT}px;
 
       &:not(:last-child) {
         border-bottom: 1px solid ${BORDER_COLOR};

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -175,6 +175,16 @@ function Template() {
           </div>
         </ListContainer>
       </Column>
+      <Column>
+        <ListContainer headerItem="ListContainer width 조절 테스트" width="500px">
+          <div>
+            <Text size={FONT.SIZE.MEDIUM}>텍스트1</Text>
+          </div>
+          <div>
+            <Text size={FONT.SIZE.MEDIUM}>텍스트2</Text>
+          </div>
+        </ListContainer>
+      </Column>
     </Wrap>
   );
 }

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -5,6 +5,7 @@ import Button from 'components/common/Button';
 import Icon from 'components/common/Icon';
 import Input from 'components/common/Input';
 import Label from 'components/common/Label';
+import ListContainer from 'components/common/ListContainer';
 import Logo from 'components/common/Logo';
 import Text from 'components/common/Text';
 import { COLOR } from 'styles/color';
@@ -161,6 +162,18 @@ function Template() {
           inputId="template-input3"
           inputLabel="label"
         />
+      </Column>
+
+      <Title>ListContainer</Title>
+      <Column>
+        <ListContainer headerItem="ListContainer테스트">
+          <div>
+            <Text size={FONT.SIZE.MEDIUM}>텍스트1</Text>
+          </div>
+          <div>
+            <Text size={FONT.SIZE.MEDIUM}>텍스트2</Text>
+          </div>
+        </ListContainer>
       </Column>
     </Wrap>
   );

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -3,6 +3,7 @@ import IssueLabel from 'components/IssueLabel';
 import Avatar from 'components/common/Avatar';
 import Button from 'components/common/Button';
 import Icon from 'components/common/Icon';
+import Input from 'components/common/Input';
 import Label from 'components/common/Label';
 import Logo from 'components/common/Logo';
 import Text from 'components/common/Text';
@@ -108,6 +109,7 @@ function Template() {
         <Avatar size="LARGE" imgSource="https://placeimg.com/44/44/animals" />
         <Avatar size="SMALL" imgSource="https://placeimg.com/20/20/animals" />
       </Column>
+
       <Title>Buttons</Title>
       <Column>
         <Button
@@ -137,12 +139,36 @@ function Template() {
           버튼 MEDIUM_TEXT
         </Button>
       </Column>
+
+      <Title>Input</Title>
+      <Column>
+        <Input
+          placeholder="placeholder"
+          template="MEDIUM"
+          inputId="template-input1"
+          inputLabel="label"
+        />
+        <Input
+          placeholder="placeholder"
+          template="LARGE"
+          inputId="template-input2"
+          inputLabel="label"
+        />
+        <Input
+          placeholder="placeholder"
+          width="500px"
+          template="SMALL"
+          inputId="template-input3"
+          inputLabel="label"
+        />
+      </Column>
     </Wrap>
   );
 }
 
 const Wrap = styled.div`
   display: flex;
+  padding: 20px;
   flex-direction: column;
   gap: 50px;
 `;

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import IssueLabel from 'components/IssueLabel';
+import Button from 'components/common/Button';
 import Icon from 'components/common/Icon';
 import Label from 'components/common/Label';
 import Logo from 'components/common/Logo';
@@ -100,6 +101,35 @@ function Template() {
       <Column>
         <IssueLabel state="open" />
         <IssueLabel state="close" />
+      </Column>
+      <Title>Buttons</Title>
+      <Column>
+        <Button
+          template="LARGE"
+          backgroundColor={{ initial: COLOR.BLUE[100], hover: COLOR.GREEN[200] }}
+          width="300px"
+        >
+          버튼 LARGE
+        </Button>
+        <Button
+          template="MEDIUM_STANDARD"
+          backgroundColor={{ initial: COLOR.BLUE[200] }}
+          width="300px"
+        >
+          버튼 MEDIUM_STANDARD
+        </Button>
+        <Button
+          template="MEDIUM_TEXT"
+          backgroundColor={{ initial: COLOR.BLUE[100], disabled: COLOR.WHITE }}
+          width="100px"
+          borderStyle="border-radius: 30px; border: 3px solid purple;"
+          fontStyles={{
+            fontColor: { initial: COLOR.BLACK, hover: COLOR.BLUE[200], disabled: COLOR.GREEN[200] },
+          }}
+          disabled
+        >
+          버튼 MEDIUM_TEXT
+        </Button>
       </Column>
     </Wrap>
   );

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import IssueLabel from 'components/IssueLabel';
+import Avatar from 'components/common/Avatar';
 import Button from 'components/common/Button';
 import Icon from 'components/common/Icon';
 import Label from 'components/common/Label';
@@ -101,6 +102,11 @@ function Template() {
       <Column>
         <IssueLabel state="open" />
         <IssueLabel state="close" />
+      </Column>
+      <Title>Avatar</Title>
+      <Column>
+        <Avatar size="LARGE" imgSource="https://placeimg.com/44/44/animals" />
+        <Avatar size="SMALL" imgSource="https://placeimg.com/20/20/animals" />
       </Column>
       <Title>Buttons</Title>
       <Column>

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -15,6 +15,7 @@ const GlobalStyle = createGlobalStyle`
   input {
     border: none;
     width: 100%;
+    height: 100%;
     margin: 0;
     padding: 0;
 

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -17,6 +17,10 @@ const GlobalStyle = createGlobalStyle`
     width: 100%;
     margin: 0;
     padding: 0;
+
+    &:focus-visible {
+      outline: 0;
+    }
   }
 
   button { 

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -27,6 +27,12 @@ const GlobalStyle = createGlobalStyle`
   button { 
     cursor: pointer;
   }
+
+  .ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space:nowrap;
+  }
 `;
 
 export default GlobalStyle;

--- a/fe/src/styles/font.ts
+++ b/fe/src/styles/font.ts
@@ -4,6 +4,7 @@ const FONT = {
     LARGE: '24px',
     MEDIUM: '18px',
     SMALL: '16px',
+    X_SMALL: '12px',
   },
   WEIGHT: {
     REGULAR: 400,

--- a/fe/src/styles/size.ts
+++ b/fe/src/styles/size.ts
@@ -17,6 +17,20 @@ const SIZE = {
     LARGE: 44,
     SMALL: 20,
   },
+  INPUT: {
+    LARGE: {
+      WIDTH: 340,
+      HEIGHT: 64,
+    },
+    MEDIUM: {
+      WIDTH: 320,
+      HEIGHT: 56,
+    },
+    SMALL: {
+      WIDTH: 300,
+      HEIGHT: 40,
+    },
+  },
 };
 
 export default SIZE;

--- a/fe/src/styles/size.ts
+++ b/fe/src/styles/size.ts
@@ -13,6 +13,10 @@ const SIZE = {
     WIDTH: 16,
     HEIGHT: 16,
   },
+  AVATAR: {
+    LARGE: 44,
+    SMALL: 20,
+  },
 };
 
 export default SIZE;

--- a/fe/src/styles/size.ts
+++ b/fe/src/styles/size.ts
@@ -31,6 +31,20 @@ const SIZE = {
       HEIGHT: 40,
     },
   },
+  LIST_CONTAINER: {
+    WIDTH: 1280,
+    PADDING_LEFT: 32,
+    BORDER_RADIUS: 16,
+    HEADER: {
+      HEIGHT: 64,
+      PADDING_TOP: 18,
+      FONT_SIZE: 16,
+    },
+    BODY: {
+      ITEM_HEIGHT: 100,
+      PADDING_TOP: 16,
+    },
+  },
 };
 
 export default SIZE;


### PR DESCRIPTION
### Description

Avatar, Input, ListContainer, Button 컴포넌트 및 Template 작업

### Commits

#25 

- `<Avatar />`, `<Input />` ,`<ListContainer />` ,`<Button />` 구현
- Template 에 추가

- `SIZE`만 추출 가능한 컴포넌트는 `size.ts`로 옮겼습니다
- 컴포넌트 함수 - styled-component -  type이나 interface 순으로 작성했습니다.
- `Button`컴포넌트는 onClick을 추후 구현하면서 type 수정 할 것으로 생각하고 `()=> void`로 작성했습니다.
- Input 컴포넌트 MEDIUM, LARGE는 placeholder와 label에 문자열을 동일한 값으로 입력하면 디자인과 동일하게 사용가능
- Input 컴포넌트 내부에 state등은 임시로 구현했습니다.. 추후에 컴포넌트 조립?하여 작성시에 수정해야하면 수정가능

### 결과

![image](https://user-images.githubusercontent.com/78826879/174476134-6c824124-7d9b-401a-ae2b-ccd7bc810940.png)

