### PR TITLE
[FE] Label List 구현

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import IssueList from 'pages/IssueList';
+import LabelList from 'pages/LabelList';
 import Template from 'pages/Template';
 import GlobalStyle from 'styles/GlobalStyle';
 
@@ -12,6 +13,7 @@ function App() {
           <Route path="/" element={<div />} />
           <Route path="/template" element={<Template />} />
           <Route path="/issueList" element={<IssueList />} />
+          <Route path="/labelList" element={<LabelList />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/fe/src/components/LabelItem.tsx
+++ b/fe/src/components/LabelItem.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+import { COLOR } from 'styles/color';
+import FONT from 'styles/font';
+import ButtonLink from './common/Button/ButtonLink';
+import Icon from './common/Icon';
+
+function LabelItem({ id, label, desc }: LabelItemProps) {
+  return (
+    <Wrapper>
+      <div className="label-area">{label}</div>
+      <div className="desc-area">{desc}</div>
+      <div className="button-area">
+        <ButtonLink
+          template="SMALL_TEXT"
+          backgroundColor={{ initial: COLOR.WHITE }}
+          fontStyles={{
+            fontColor: {
+              initial: COLOR.GREY[500],
+            },
+            fontSize: FONT.SIZE.X_SMALL,
+            fontWeight: FONT.WEIGHT.BOLD,
+          }}
+          to={`/${id}`}
+        >
+          <Icon icon="edit" stroke={COLOR.GREY[500]} />
+          편집
+        </ButtonLink>
+        <ButtonLink
+          template="SMALL_TEXT"
+          backgroundColor={{ initial: COLOR.WHITE }}
+          fontStyles={{
+            fontColor: {
+              initial: COLOR.RED[200],
+            },
+            fontSize: FONT.SIZE.X_SMALL,
+            fontWeight: FONT.WEIGHT.BOLD,
+          }}
+          to={`/${id}`}
+        >
+          <Icon icon="trash" stroke={COLOR.RED[200]} />
+          삭제
+        </ButtonLink>
+      </div>
+    </Wrapper>
+  );
+}
+
+export default LabelItem;
+
+type LabelItemProps = {
+  id: string;
+  label: JSX.Element;
+  desc: string;
+};
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: 2fr 5fr 2fr;
+  align-items: center;
+
+  .desc-area {
+    font-size: ${FONT.SIZE.SMALL};
+    color: ${COLOR.GREY[500]};
+  }
+
+  .button-area {
+    display: flex;
+    justify-content: flex-end;
+  }
+`;

--- a/fe/src/components/LabelItem.tsx
+++ b/fe/src/components/LabelItem.tsx
@@ -47,7 +47,7 @@ function LabelItem({ id, label, desc }: LabelItemProps) {
 
 export default LabelItem;
 
-type LabelItemProps = {
+export type LabelItemProps = {
   id: string;
   label: JSX.Element;
   desc: string;

--- a/fe/src/components/SubNav.tsx
+++ b/fe/src/components/SubNav.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import { COLOR } from 'styles/color';
+import mainHeaderStyle from 'styles/mainHeaderStyle';
+import ButtonLink from './common/Button/ButtonLink';
+import Icon from './common/Icon';
+import Tabs, { ActiveItemType } from './common/Tabs';
+
+function SubNav({ location, linkTo }: SubNavProps) {
+  return (
+    <MainHeader>
+      <Tabs activeItem={location} />
+      <ButtonLink
+        template="SMALL_STANDARD"
+        backgroundColor={{ initial: COLOR.BLUE[200], hover: COLOR.BLUE[300] }}
+        to={linkTo}
+      >
+        <Icon icon="plus" stroke={COLOR.WHITE} /> 추가
+      </ButtonLink>
+    </MainHeader>
+  );
+}
+
+export default SubNav;
+
+const MainHeader = styled.div`
+  ${mainHeaderStyle}
+`;
+
+type SubNavProps = {
+  location: ActiveItemType;
+  linkTo: string;
+};

--- a/fe/src/components/common/Label.tsx
+++ b/fe/src/components/common/Label.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import FONT from 'styles/font';
 
 function Label({ backgroundColor, color, children, borderColor }: LabelProps) {
   return (
@@ -14,6 +15,7 @@ const Wrap = styled.div<WrapProps>`
   border-radius: 30px;
   background-color: ${({ backgroundColor }) => backgroundColor};
   color: ${({ color }) => color};
+  font-size: ${FONT.SIZE.X_SMALL};
   border: ${({ borderColor }) => borderColor && `1px solid ${borderColor}`};
 `;
 

--- a/fe/src/components/common/Tabs.tsx
+++ b/fe/src/components/common/Tabs.tsx
@@ -34,7 +34,7 @@ function Tabs({ activeItem = null }: { activeItem?: ActiveItemType }) {
 
 export default Tabs;
 
-type ActiveItemType = 'LABEL' | 'MILESTONE' | null;
+export type ActiveItemType = 'LABEL' | 'MILESTONE' | null;
 
 const tabsButtonBackGroundColors = { initial: 'transparent', hover: COLOR.GREY[200] };
 

--- a/fe/src/pages/IssueList.tsx
+++ b/fe/src/pages/IssueList.tsx
@@ -16,6 +16,8 @@ const ISSUES: IssueType[] = [
   { id: '3456', number: 3, title: '비비 천재 3', author: '비비', milestone: '마일스톤 3' },
 ];
 
+const isEmptyIssue = ISSUES.length === 0;
+
 type IssueType = {
   id: string;
   number: number;
@@ -42,7 +44,7 @@ function IssueList() {
         </div>
       </MainHeader>
       <ListContainer headerItem={<div>헤더</div>}>
-        {ISSUES.length ? (
+        {(!isEmptyIssue &&
           ISSUES.map(({ id, number, title, author, milestone }) => (
             <IssueItem
               key={id}
@@ -51,10 +53,7 @@ function IssueList() {
               author={author}
               milestone={milestone}
             />
-          ))
-        ) : (
-          <BlankMessage text="등록된 이슈가 없습니다" />
-        )}
+          ))) || <BlankMessage text="등록된 이슈가 없습니다" />}
       </ListContainer>
     </main>
   );

--- a/fe/src/pages/IssueList.tsx
+++ b/fe/src/pages/IssueList.tsx
@@ -8,6 +8,7 @@ import Icon from 'components/common/Icon';
 import ListContainer from 'components/common/ListContainer';
 import Tabs from 'components/common/Tabs';
 import { COLOR } from 'styles/color';
+import mainHeaderStyle from 'styles/mainHeaderStyle';
 
 const ISSUES: IssueType[] = [
   { id: '1234', number: 1, title: '비비 천재 1', author: '비비', milestone: '마일스톤 1' },
@@ -60,9 +61,7 @@ function IssueList() {
 }
 
 const MainHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 24px;
+  ${mainHeaderStyle};
 
   .button-area {
     display: flex;

--- a/fe/src/pages/LabelList.tsx
+++ b/fe/src/pages/LabelList.tsx
@@ -1,0 +1,55 @@
+import LabelItem, { LabelItemProps } from 'components/LabelItem';
+import SubNav from 'components/SubNav';
+import BlankMessage from 'components/common/BlankMessage';
+import Header from 'components/common/Header';
+import Label from 'components/common/Label';
+import ListContainer from 'components/common/ListContainer';
+
+const LABEL_MOCK_DATA: LabelItemProps[] = [
+  {
+    id: '123',
+    label: (
+      <Label color="white" backgroundColor="blue">
+        라벨1
+      </Label>
+    ),
+    desc: '123 라벨에 대한 설명',
+  },
+  {
+    id: '234',
+    label: (
+      <Label color="white" backgroundColor="green">
+        label test
+      </Label>
+    ),
+    desc: 'label test 라벨에 대한 설명',
+  },
+  {
+    id: '343',
+    label: (
+      <Label color="white" backgroundColor="red">
+        또 다른 라벨
+      </Label>
+    ),
+    desc: '또 다른 라벨에 대한 설명',
+  },
+];
+
+const isEmptyData = LABEL_MOCK_DATA.length === 0;
+
+function LabelList() {
+  return (
+    <main className="wrap">
+      <Header avatarUrl="null" />
+      <SubNav location="LABEL" linkTo="/" />
+      <ListContainer headerItem={<div>헤더</div>}>
+        {(!isEmptyData &&
+          LABEL_MOCK_DATA.map(({ id, label, desc }) => (
+            <LabelItem id={id} key={id} label={label} desc={desc} />
+          ))) || <BlankMessage text="등록된 라벨이 없습니다" />}
+      </ListContainer>
+    </main>
+  );
+}
+
+export default LabelList;

--- a/fe/src/pages/LabelList.tsx
+++ b/fe/src/pages/LabelList.tsx
@@ -4,6 +4,9 @@ import BlankMessage from 'components/common/BlankMessage';
 import Header from 'components/common/Header';
 import Label from 'components/common/Label';
 import ListContainer from 'components/common/ListContainer';
+import Text from 'components/common/Text';
+import { COLOR } from 'styles/color';
+import FONT from 'styles/font';
 
 const LABEL_MOCK_DATA: LabelItemProps[] = [
   {
@@ -35,18 +38,25 @@ const LABEL_MOCK_DATA: LabelItemProps[] = [
   },
 ];
 
-const isEmptyData = LABEL_MOCK_DATA.length === 0;
+const dataCount = LABEL_MOCK_DATA.length;
+const isEmptyData = dataCount === 0;
 
 function LabelList() {
   return (
     <main className="wrap">
       <Header avatarUrl="null" />
       <SubNav location="LABEL" linkTo="/" />
-      <ListContainer headerItem={<div>헤더</div>}>
+      <ListContainer
+        headerItem={
+          <Text weight={FONT.WEIGHT.BOLD} color={COLOR.GREY[500]}>
+            {dataCount}개의 레이블
+          </Text>
+        }
+      >
         {(!isEmptyData &&
           LABEL_MOCK_DATA.map(({ id, label, desc }) => (
             <LabelItem id={id} key={id} label={label} desc={desc} />
-          ))) || <BlankMessage text="등록된 라벨이 없습니다" />}
+          ))) || <BlankMessage text="등록된 이 없습니다" />}
       </ListContainer>
     </main>
   );

--- a/fe/src/styles/mainHeaderStyle.ts
+++ b/fe/src/styles/mainHeaderStyle.ts
@@ -1,0 +1,9 @@
+import { css } from 'styled-components';
+
+const mainHeaderStyle = css`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 24px;
+`;
+
+export default mainHeaderStyle;


### PR DESCRIPTION
### Description

Label List 구현 및 부가 컴포넌트들 구현

### Commits

04f9515 :sparkles: LabelList의 List header 구현
580c632 :sparkles: LabelList 구현 및 스타일링
d47261b :sparkles: SubNav 컴포넌트 구현 및 Tabs prop type export
6bdbb6f :sparkles: LabelItem 컴포넌트 구현
618bba5 :bug: Label 컴포넌트 font-size 수정
3ae0942 :recycle: MainHeader 스타일 리팩토링 및 분리

### 결과

![image](https://user-images.githubusercontent.com/78826879/174806545-db9a377d-a5d6-4d35-96b2-668749969391.png)

