### PR TITLE
[FE] 컴포넌트, styles 일부 리팩토링

### DIFF
--- a/fe/src/components/FilterBar.tsx
+++ b/fe/src/components/FilterBar.tsx
@@ -27,17 +27,20 @@ function FilterBar({ placeholder }: { placeholder: string }) {
         필터 아이템
       </DropdownBtn>
 
-      <div className="input-area">
-        <Icon icon="search" stroke="inherit" />
-        <input
-          type="text"
-          className="input-text"
-          placeholder={placeholder}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          onChange={onChange}
-          value={inputText}
-        />
+      <div className="input-area flex-center">
+        <label htmlFor="filter-bar-input" className="flex-center">
+          <Icon icon="search" stroke="inherit" />
+          <input
+            type="text"
+            className="input-text"
+            placeholder={placeholder}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            onChange={onChange}
+            value={inputText}
+            id="filter-bar-input"
+          />
+        </label>
       </div>
     </Wrapper>
   );
@@ -61,9 +64,6 @@ const Wrapper = styled.div<{ isFocused: boolean }>`
   .input-area {
     width: 472px;
     height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     stroke: ${COLOR.GREY[400]};
     background-color: ${({ isFocused }) => (isFocused ? COLOR.WHITE : COLOR.GREY[200])};
     border-left: 1px solid ${COLOR.GREY[300]};

--- a/fe/src/components/IssueItem.tsx
+++ b/fe/src/components/IssueItem.tsx
@@ -15,7 +15,7 @@ function IssueItem({ number, title, author, milestone }: IssueItemProps) {
       <Contents>
         <Title>
           <Icon icon="alertCircle" stroke={COLOR.BLUE[200]} fill={COLOR.BLUE[100]} />
-          <Text size={FONT.SIZE.MEDIUM} weight={FONT.WEIGHT.BOLD}>
+          <Text size={FONT.SIZE.MEDIUM} weight={FONT.WEIGHT.BOLD} className="ellipsis">
             {title}
           </Text>
           <Label color={COLOR.WHITE} backgroundColor={COLOR.BLUE[300]}>

--- a/fe/src/components/LabelItem.tsx
+++ b/fe/src/components/LabelItem.tsx
@@ -3,12 +3,15 @@ import { COLOR } from 'styles/color';
 import FONT from 'styles/font';
 import ButtonLink from './common/Button/ButtonLink';
 import Icon from './common/Icon';
+import Text from './common/Text';
 
 function LabelItem({ id, label, desc }: LabelItemProps) {
   return (
     <Wrapper>
       <div className="label-area">{label}</div>
-      <div className="desc-area">{desc}</div>
+      <Text className="ellipsis" color={COLOR.GREY[500]}>
+        {desc}
+      </Text>
       <div className="button-area">
         <ButtonLink
           template="SMALL_TEXT"
@@ -57,11 +60,6 @@ const Wrapper = styled.div`
   display: grid;
   grid-template-columns: 2fr 5fr 2fr;
   align-items: center;
-
-  .desc-area {
-    font-size: ${FONT.SIZE.SMALL};
-    color: ${COLOR.GREY[500]};
-  }
 
   .button-area {
     display: flex;

--- a/fe/src/components/SubNav.tsx
+++ b/fe/src/components/SubNav.tsx
@@ -1,21 +1,21 @@
 import styled from 'styled-components';
 import { COLOR } from 'styles/color';
 import mainHeaderStyle from 'styles/mainHeaderStyle';
-import ButtonLink from './common/Button/ButtonLink';
+import Button from './common/Button/Button';
 import Icon from './common/Icon';
 import Tabs, { ActiveItemType } from './common/Tabs';
 
-function SubNav({ location, linkTo }: SubNavProps) {
+function SubNav({ location }: SubNavProps) {
   return (
     <MainHeader>
       <Tabs activeItem={location} />
-      <ButtonLink
+      <Button
         template="SMALL_STANDARD"
         backgroundColor={{ initial: COLOR.BLUE[200], hover: COLOR.BLUE[300] }}
-        to={linkTo}
+        onClick={() => console.log(location)}
       >
         <Icon icon="plus" stroke={COLOR.WHITE} /> 추가
-      </ButtonLink>
+      </Button>
     </MainHeader>
   );
 }
@@ -28,5 +28,4 @@ const MainHeader = styled.div`
 
 type SubNavProps = {
   location: ActiveItemType;
-  linkTo: string;
 };

--- a/fe/src/components/common/Button/Button.tsx
+++ b/fe/src/components/common/Button/Button.tsx
@@ -15,11 +15,11 @@ function Button({
     fontWeight: BUTTON_STYLES[template].FONT_STYLE.WEIGHT,
   },
   backgroundColor,
-  className,
+  className = '',
 }: ButtonProps) {
   return (
     <CustomButton
-      className={`ellipsis flex-center ${className}`}
+      className={`flex-center ${className}`}
       onClick={onClick}
       disabled={disabled}
       width={width}

--- a/fe/src/components/common/Button/Button.tsx
+++ b/fe/src/components/common/Button/Button.tsx
@@ -19,7 +19,7 @@ function Button({
 }: ButtonProps) {
   return (
     <CustomButton
-      className={`ellipsis ${className}`}
+      className={`ellipsis flex-center ${className}`}
       onClick={onClick}
       disabled={disabled}
       width={width}

--- a/fe/src/components/common/Button/ButtonLink.tsx
+++ b/fe/src/components/common/Button/ButtonLink.tsx
@@ -15,12 +15,12 @@ function ButtonLink({
   },
   backgroundColor,
   to,
-  className,
+  className = '',
   ...props
 }: ButtonProps & LinkProps) {
   return (
     <CustomButtonLink
-      className={`ellipsis flex-center ${className}`}
+      className={`flex-center ellipsis ${className}`}
       width={width}
       height={height}
       borderStyle={borderStyle}

--- a/fe/src/components/common/Button/ButtonLink.tsx
+++ b/fe/src/components/common/Button/ButtonLink.tsx
@@ -20,7 +20,7 @@ function ButtonLink({
 }: ButtonProps & LinkProps) {
   return (
     <CustomButtonLink
-      className={`ellipsis ${className}`}
+      className={`ellipsis flex-center ${className}`}
       width={width}
       height={height}
       borderStyle={borderStyle}
@@ -51,8 +51,4 @@ const CustomButtonLink = styled(Link).withConfig({
     ].includes(prop),
 })`
   ${buttonStyle};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
 `;

--- a/fe/src/components/common/Button/button.style.ts
+++ b/fe/src/components/common/Button/button.style.ts
@@ -102,6 +102,7 @@ const buttonStyle = css<{
   fontWeight?: number;
   backgroundColor: BackGroundColors;
 }>`
+  /* min-width: 0; */
   width: ${({ width }) => width};
   height: ${({ height }) => height};
   ${({ borderStyle }) => css` ${borderStyle}}`};

--- a/fe/src/components/common/Button/button.style.ts
+++ b/fe/src/components/common/Button/button.style.ts
@@ -109,6 +109,7 @@ const buttonStyle = css<{
   font-size: ${({ fontSize }) => fontSize};
   font-weight: ${({ fontWeight }) => fontWeight};
   color: ${({ fontColor }) => fontColor?.initial};
+  gap: 10px;
 
   &:not(:disabled):hover {
     background-color: ${({ backgroundColor }) => backgroundColor.hover};

--- a/fe/src/components/common/ListContainer.tsx
+++ b/fe/src/components/common/ListContainer.tsx
@@ -23,6 +23,7 @@ const Wrapper = styled.div<{ width: string }>`
   width: ${({ width }) => width};
   border-radius: ${SIZE.LIST_CONTAINER.BORDER_RADIUS}px;
   border: 1px solid ${BORDER_COLOR};
+  margin-bottom: 27px;
   overflow: hidden;
 
   .list-header {
@@ -41,7 +42,7 @@ const Wrapper = styled.div<{ width: string }>`
     background-color: ${COLOR.WHITE};
 
     > :nth-child(n) {
-      height: ${SIZE.LIST_CONTAINER.BODY.ITEM_HEIGHT}px;
+      min-height: ${SIZE.LIST_CONTAINER.BODY.ITEM_HEIGHT}px;
       padding: ${SIZE.LIST_CONTAINER.BODY.PADDING_TOP}px ${SIZE.LIST_CONTAINER.PADDING_LEFT}px;
 
       &:not(:last-child) {

--- a/fe/src/components/common/Text.tsx
+++ b/fe/src/components/common/Text.tsx
@@ -6,10 +6,11 @@ function Text({
   size = FONT.SIZE.SMALL,
   weight = FONT.WEIGHT.REGULAR,
   color = COLOR.BLACK,
+  className = '',
   children,
 }: TextProps) {
   return (
-    <Span size={size} weight={weight} color={color}>
+    <Span size={size} weight={weight} color={color} className={className}>
       {children}
     </Span>
   );
@@ -19,6 +20,7 @@ type TextProps = {
   size?: string;
   weight?: number;
   color?: string;
+  className?: string;
   children: React.ReactNode;
 };
 

--- a/fe/src/pages/LabelList.tsx
+++ b/fe/src/pages/LabelList.tsx
@@ -45,7 +45,7 @@ function LabelList() {
   return (
     <main className="wrap">
       <Header avatarUrl="null" />
-      <SubNav location="LABEL" linkTo="/" />
+      <SubNav location="LABEL" />
       <ListContainer
         headerItem={
           <Text weight={FONT.WEIGHT.BOLD} color={COLOR.GREY[500]}>

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import IssueLabel from 'components/IssueLabel';
 import Avatar from 'components/common/Avatar';
@@ -128,7 +127,9 @@ function Template() {
           backgroundColor={{ initial: COLOR.BLUE[200] }}
           width="300px"
         >
-          버튼 MEDIUM_STANDARD
+          <span className="ellipsis">
+            버튼 MEDIUM_STANDARD버튼 MEDIUM_STANDARD버튼 MEDIUM_STANDARD버튼 MEDIUM_STANDARD
+          </span>
         </Button>
         <Button
           template="MEDIUM_TEXT"
@@ -140,7 +141,7 @@ function Template() {
           }}
           disabled
         >
-          버튼 MEDIUM_TEXT
+          <span className="ellipsis">버튼 MEDIUM_TEXT</span>
         </Button>
       </Column>
 
@@ -198,8 +199,10 @@ function Template() {
           <div>이러한 리스트</div>
         </DropdownBtn>
       </Row>
+
       <Column>
-        <Link to="/">하이</Link>
+        <Title>ButtonLink</Title>
+
         <ButtonLink
           template="MEDIUM_STANDARD"
           backgroundColor={{ initial: COLOR.GREEN[200] }}

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -44,6 +44,12 @@ const GlobalStyle = createGlobalStyle`
     max-width: ${SIZE.WIDTH}px;
     margin: 0 auto;
   }
+
+  .flex-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
### Description

- SubNav의 ButtonLink를 `Button`으로 변경하였습니다(임시로 onClick은 `console.log`입니다)
- ListContainer의 높이를 `min-height`로 변경하여 리스트 아이템에 높이가 있는 경우 올바르게 표시할 수 있도록 변경하였습니다.
- FilterBar의 검색아이콘(🔍︎)을 `<label>`로 변경하여 클릭 시에 input에 focus가 갈 수 있도록 수정하였습니다.
- `GlobalStyle.ts`에 `flex-center` 클래스를 추가하여 flex를 이용한 가운데 정렬을 쉽게 이용하도록 하였습니다.
  - 어디서든 클래스 추가로 이용가능합니다😊
  - styled-component의 css``로 이용하고 싶거나, 클래스 명을 변경하고 싶은 경우 변경하셔도 될 것 같아요~ 적용되어있는 파일에서 수정하고 공유만 해주시면 돼요~
    - 현재 적용된 파일: FilterBar, Button, ButtonLink
  ```css
  .flex-center {
    display: flex;
    align-items: center;
    justify-content: center;
  }
  ```
- Button(ButtonLink) 내부 중앙 정렬을 `flex`를 이용하다 보니 ellipsis적용이 안됩니다 ([참고링크](https://stackoverflow.com/questions/39838908/text-overflow-ellipsis-not-working-in-nested-flexbox))
  - Button, ButtonLink의 ellipsis 클래스를 제거하였고, 필요시 템플릿의 사용 예 처럼 아래와 같이 사용하면 될 것 같습니다! 
  -  `{children}`을 태그로 감싸고, `ellipsis` 클래스 추가
  ```html
  <Button
          template="MEDIUM_STANDARD"
          backgroundColor={{ initial: COLOR.BLUE[200] }}
          width="300px"
   >
       <span className="ellipsis">
         버튼 MEDIUM_STANDARD버튼 MEDIUM_STANDARD버튼 MEDIUM_STANDARD버튼 MEDIUM_STANDARD
       </span>
   </Button>
  ```
- issueList, labelList의 가운데 텍스트 영역에 `ellipsis` 클래스 추가하였습니다.
  - Text에 class를 추가하기위해 `className` prop을 추가하였습니다.
 
![image](https://user-images.githubusercontent.com/78826879/174831379-aeb1fdfa-54bf-4f31-8e29-6322045974bd.png)


### Commits

8b24561 :lipstick: IssueItem, LabelItem에 ellipsis 스타일 추가
8656913 :recycle: Template 페이지 수정 및 Button 스타일 리팩토링
285578e :recycle: SubNav Button변경 및 buttonStyle 리팩토링
36a53b0 :bug: ListContainer의 Item에 높이 제한 삭제
36c8134 :recycle: FilterBar 리팩토링 및 .flex-center 추가



