### PR TITLE
[FE] 로그인 페이지 화면 및 global style에 부모 요소 높이 지정

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import IssueList from 'pages/IssueList';
 import LabelList from 'pages/LabelList';
+import Login from 'pages/Login';
 import Template from 'pages/Template';
 import GlobalStyle from 'styles/GlobalStyle';
 
@@ -14,6 +15,7 @@ function App() {
           <Route path="/template" element={<Template />} />
           <Route path="/issueList" element={<IssueList />} />
           <Route path="/labelList" element={<LabelList />} />
+          <Route path="/login" element={<Login />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/fe/src/components/common/Button/button.style.ts
+++ b/fe/src/components/common/Button/button.style.ts
@@ -5,7 +5,7 @@ import FONT from 'styles/font';
 const BUTTON_STYLES = {
   LARGE: {
     SIZE: {
-      WIDTH: 240,
+      WIDTH: 340,
       HEIGHT: 64,
     },
     FONT_STYLE: {

--- a/fe/src/components/common/Tabs.tsx
+++ b/fe/src/components/common/Tabs.tsx
@@ -13,7 +13,7 @@ function Tabs({ activeItem = null }: { activeItem?: ActiveItemType }) {
         width="160px"
         height="40px"
         className={`tab-item ${activeItem === 'LABEL' ? 'active' : ''}`}
-        to="/"
+        to="/labelList"
       >
         <Icon icon="tag" stroke="inherit" /> 레이블 <span className="count">(0)</span>
       </ButtonLink>
@@ -23,7 +23,7 @@ function Tabs({ activeItem = null }: { activeItem?: ActiveItemType }) {
         width="160px"
         height="40px"
         className={`tab-item ${activeItem === 'MILESTONE' ? 'active' : ''}`}
-        to="/"
+        to="/milestoneList"
       >
         <Icon icon="milestone" stroke="transparent" fill="inherit" /> 마일스톤
         <span className="count">(0)</span>

--- a/fe/src/pages/Login.tsx
+++ b/fe/src/pages/Login.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import ButtonLink from 'components/common/Button/ButtonLink';
+import Logo from 'components/common/Logo';
+import { COLOR } from 'styles/color';
+import FONT from 'styles/font';
+
+function Login() {
+  return (
+    <Wrapper className="flex-center">
+      <Logo size="LARGE" />
+      <ButtonLink
+        template="LARGE"
+        backgroundColor={{ initial: COLOR.BLACK }}
+        fontStyles={{ fontColor: { initial: COLOR.WHITE }, fontWeight: FONT.WEIGHT.BOLD }}
+        to="/"
+      >
+        <span className="flex-center">GitHub 계정으로 로그인</span>
+      </ButtonLink>
+    </Wrapper>
+  );
+}
+
+export default Login;
+
+const Wrapper = styled.div`
+  flex-direction: column;
+  height: 100%;
+
+  > :not(:last-child) {
+    margin-bottom: 60px;
+  }
+`;

--- a/fe/src/styles/GlobalStyle.ts
+++ b/fe/src/styles/GlobalStyle.ts
@@ -9,6 +9,10 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: border-box;
   }
 
+  html, body, #root {
+    height: 100%
+  }
+
   body * {
     font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
   }


### PR DESCRIPTION
### Description

로그인 페이지 화면 및 global style에 부모 요소 높이 지정

- 작업하면서 Tabs에서 링크 `/`로 되어있던 것 `/labelList` 등 올바른 링크 주소로 수정했습니다! (cf76b23)

### Commits
cf76b23 :bug: Tabs의 잘못된 링크 수정
92e929d :sparkles: Login 페이지 화면 구현
80513f7 :lipstick: GlobalStyle에 부모 요소 높이 추가
ec31f3e :bug: button.style 사이즈 오류 해결

### 결과

![image](https://user-images.githubusercontent.com/78826879/174937310-e6f1d7bb-fadd-4e76-bddd-0c9097cd5516.png)

