### PR TITLE
[FE] 로그인 성공/실패에 따른 화면 렌더링

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -13,13 +13,12 @@ function App() {
       <GlobalStyle />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<div />} />
+          <Route path="/" element={<Login />} />
+          <Route path="/callback" element={<Callback />} />
           <Route path="/template" element={<Template />} />
           <Route path="/issueList" element={<IssueList />} />
           <Route path="/labelList" element={<LabelList />} />
           <Route path="/milestoneList" element={<MilestoneList />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/callback" element={<Callback />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/fe/src/components/common/Error.tsx
+++ b/fe/src/components/common/Error.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import { COLOR } from 'styles/color';
+import { flexCenterStyle } from 'styles/commonStyles';
+import FONT from 'styles/font';
+import ButtonLink from './Button/ButtonLink';
+import Text from './Text';
+
+function Error({ message }: { message?: string }) {
+  return (
+    <Wrapper>
+      <TextContainer>
+        <Text size={FONT.SIZE.LARGE} weight={FONT.WEIGHT.BOLD}>
+          ⚠️ Something went wrong! ⚠️
+        </Text>
+        <Text>{message || '오류가 발생했습니다. 다시 시도해주세요.'}</Text>
+      </TextContainer>
+      <ButtonLink to="/" template="MEDIUM_STANDARD" backgroundColor={{ initial: COLOR.BLUE[200] }}>
+        돌아가기
+      </ButtonLink>
+    </Wrapper>
+  );
+}
+
+export default Error;
+
+const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  ${flexCenterStyle}
+  flex-direction: column;
+`;
+
+const TextContainer = styled.div`
+  ${flexCenterStyle}
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;

--- a/fe/src/components/common/Loading/Spinner.tsx
+++ b/fe/src/components/common/Loading/Spinner.tsx
@@ -1,0 +1,25 @@
+import styled, { keyframes } from 'styled-components';
+
+function Spinner() {
+  return <Circle />;
+}
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+const Circle = styled.div`
+  width: 100px;
+  height: 100px;
+  border: 25px solid #2c3e50;
+  border-radius: 50%;
+  border-top-color: #7f8c8d;
+  animation: ${rotate} 1s linear infinite;
+`;
+
+export default Spinner;

--- a/fe/src/components/common/Loading/index.tsx
+++ b/fe/src/components/common/Loading/index.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import Spinner from 'components/common/Loading/Spinner';
+import { flexCenterStyle } from 'styles/commonStyles';
+
+function Loading() {
+  return (
+    <Wrap>
+      <Spinner />
+    </Wrap>
+  );
+}
+
+const Wrap = styled.div`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  ${flexCenterStyle}
+`;
+
+export default Loading;

--- a/fe/src/pages/Callback.tsx
+++ b/fe/src/pages/Callback.tsx
@@ -1,7 +1,4 @@
-// import { useEffect } from 'react';
-
-// import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import useFetchFromIssueTracker from 'hooks/useFetchFromIssueTracker';
 import useLocalStorage from 'hooks/useLocalStorage';
 
@@ -10,26 +7,29 @@ function Callback() {
   const [, setAccessToken] = useLocalStorage({ key: 'user_info' });
 
   const code = searchParams.get('code');
-  const { data: userDataResponse, error } = useFetchFromIssueTracker({
+  const { data, error } = useFetchFromIssueTracker({
     url: `api/login/token?code=${code}`,
   });
+
+  const navigate = useNavigate();
 
   if (error) {
     return <div>실패</div>;
   }
 
-  if (!userDataResponse) {
+  if (!data) {
     return <div>로딩중</div>;
   }
 
-  // if (userDataResponse.data) {
-  const { accessToken: token, name, email, avatarUrl } = userDataResponse;
+  const { accessToken, name, email, avatarUrl } = data;
 
-  const newData = { token, name: name || '익명의 쿼카', email, avatarUrl };
+  const newData = { accessToken, name: name || '익명의 쿼카', email, avatarUrl };
 
   setAccessToken(newData);
-  // }
-  return <div>나는 콜백 페이지야.</div>;
+
+  navigate('/issueList');
+
+  return <div />;
 }
 
 export default Callback;

--- a/fe/src/pages/Callback.tsx
+++ b/fe/src/pages/Callback.tsx
@@ -1,6 +1,9 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import Loading from 'components/common/Loading';
 import useFetchFromIssueTracker from 'hooks/useFetchFromIssueTracker';
 import useLocalStorage from 'hooks/useLocalStorage';
+
+const USER_DEFAULT_NAME = '익명의 쿼카';
 
 function Callback() {
   const [searchParams] = useSearchParams();
@@ -11,25 +14,19 @@ function Callback() {
     url: `api/login/token?code=${code}`,
   });
 
-  const navigate = useNavigate();
-
   if (error) {
     return <div>실패</div>;
   }
 
   if (!data) {
-    return <div>로딩중</div>;
+    return <Loading />;
   }
 
   const { accessToken, name, email, avatarUrl } = data;
+  const userData = { accessToken, name: name || USER_DEFAULT_NAME, email, avatarUrl };
+  setAccessToken(userData);
 
-  const newData = { accessToken, name: name || '익명의 쿼카', email, avatarUrl };
-
-  setAccessToken(newData);
-
-  navigate('/issueList');
-
-  return <div />;
+  return <Navigate to="/issueList" />;
 }
 
 export default Callback;

--- a/fe/src/pages/Callback.tsx
+++ b/fe/src/pages/Callback.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useSearchParams } from 'react-router-dom';
+import Error from 'components/common/Error';
 import Loading from 'components/common/Loading';
 import useFetchFromIssueTracker from 'hooks/useFetchFromIssueTracker';
 import useLocalStorage from 'hooks/useLocalStorage';
@@ -15,7 +16,7 @@ function Callback() {
   });
 
   if (error) {
-    return <div>실패</div>;
+    return <Error message="로그인에 실패하였습니다. 다시 시도해주세요." />;
   }
 
   if (!data) {

--- a/fe/src/pages/Template.tsx
+++ b/fe/src/pages/Template.tsx
@@ -9,6 +9,7 @@ import Input from 'components/common/Input/Input';
 import Label from 'components/common/Label';
 import LinearGraph from 'components/common/LinearGraph';
 import ListContainer from 'components/common/ListContainer';
+import Spinner from 'components/common/Loading/Spinner';
 import Logo from 'components/common/Logo';
 import Text from 'components/common/Text';
 import { COLOR } from 'styles/color';
@@ -18,6 +19,7 @@ import FONT from 'styles/font';
 function Template() {
   return (
     <Wrap>
+      <Spinner />
       <Title>Logo</Title>
       <Column>
         <Logo size="MEDIUM" />


### PR DESCRIPTION
### Description

로그인 성공/실패에 따른 화면 렌더링

### Commits

c062d2ec :sparkles: Error컴포넌트 구현 및 Callback과 연결
bd988b0f :sparkles: '/' 라우팅 주소 변경
5d244d5e :bug: 로그인 성공시 issueList 이동 오류 해결
2295025b :sparkles: 로딩 컴포넌트 생성 / 성공 시 IssueList 페이지 이동


### 결과

![screenissueTracker](https://user-images.githubusercontent.com/78826879/176365193-c999b838-ecdf-4c36-9b19-ff2f9e209d2b.gif)

![image](https://user-images.githubusercontent.com/78826879/176365031-92edd761-89d8-4fcb-a7e6-136c7b2d6917.png)
